### PR TITLE
Fixed the tweet_button example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ More information can be found from [Twitter](https://twitter.com/about/resources
 So, if you wanted to tweet about Hacker News, attribute it to Peter Cooper, and add some custom text, all from a tweet button with a horizontal counter, you'd do this:
 
 ```erb
-<%= tweet_button(via: => "peterc", url: "http://news.ycombinator.com", :text => "AWESOME.") %>
+<%= tweet_button(via: "peterc", url: "http://news.ycombinator.com", text: "AWESOME.") %>
 ```
 
 ### Like Button


### PR DESCRIPTION
The following tweet_button example will give Syntax error
<%= tweet_button(via: => "peterc", url: "http://news.ycombinator.com", :text => "AWESOME.") %> 

The issue is with following
via: => "peterc" 
The hash is not defined correctly. It should be either 
via: "peterc" 
or 
:via => "peterc"
